### PR TITLE
Checklocalecode

### DIFF
--- a/Pod/Locale.swift
+++ b/Pod/Locale.swift
@@ -11,6 +11,7 @@ import zipzap
 
 private let languageComponents = NSLocale.componentsFromLocaleIdentifier(NSLocale.currentLocale().localeIdentifier)
 private let languageCode = languageComponents[NSLocaleLanguageCode] ?? Constants.BaseLocaleName
+private let countryCode = languageComponents[NSLocaleCountryCode] ?? ""
 private let scriptCode = languageComponents[NSLocaleScriptCode]
 
 @objc public final class Locale: NSObject {
@@ -97,6 +98,16 @@ private let scriptCode = languageComponents[NSLocaleScriptCode]
             localizations[locale] = merged
         }
 
+    }
+    
+    public class func activeLocaleEqualsCode(code: String) -> Bool {
+        
+        let fullLocaleCode = languageCode + "-" + countryCode
+        
+        let containsCode = fullLocaleCode == code
+        
+        return containsCode
+        
     }
 
     // MARK: Localizations

--- a/Pod/Locale.swift
+++ b/Pod/Locale.swift
@@ -104,9 +104,7 @@ private let scriptCode = languageComponents[NSLocaleScriptCode]
         
         let fullLocaleCode = languageCode + "-" + countryCode
         
-        let containsCode = fullLocaleCode == code
-        
-        return containsCode
+        return fullLocaleCode == code
         
     }
 


### PR DESCRIPTION
Note that the country code, when using the simulator, can be nil so I am defaulting it to "". You can get around this issue by being sure to set the Application Language and Application Region in your Xcode scheme. 